### PR TITLE
Ensure Telegram bot has job queue support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-python-telegram-bot==21.*
+python-telegram-bot[job-queue]==21.*
 httpx==0.27.*
 feedparser==6.*


### PR DESCRIPTION
## Summary
- install python-telegram-bot with the job-queue extra so the Application's job queue is available

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile jokebot.py`
- `python - <<'PY' from telegram.ext import Application; app = Application.builder().token('42:ABC').build(); print(type(app.job_queue))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68aef3a941588333b38a4f7fa6434b5e