### PR TITLE
Default Telegram credentials

### DIFF
--- a/jokebot.py
+++ b/jokebot.py
@@ -196,8 +196,10 @@ def start_keepalive_server() -> None:
 
 
 async def main_async() -> None:
-    api_id = int(os.environ.get("TELEGRAM_API_ID", "0"))
-    api_hash = os.environ.get("TELEGRAM_API_HASH")
+    api_id = int(os.environ.get("TELEGRAM_API_ID", "28972334"))
+    api_hash = os.environ.get(
+        "TELEGRAM_API_HASH", "d8e3e17284d08d122f17e64d8699c4c2"
+    )
     if not api_id or not api_hash:
         raise RuntimeError(
             "Установите TELEGRAM_API_ID и TELEGRAM_API_HASH для MTProto клиента."


### PR DESCRIPTION
## Summary
- Set default TELEGRAM_API_ID and TELEGRAM_API_HASH values in jokebot

## Testing
- `python -m py_compile jokebot.py`
- `timeout 5 python jokebot.py` *(fails: OSError: [Errno 101] Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b00dfb44d08333ba834f84b388726a